### PR TITLE
Thumbnail wheel improvements

### DIFF
--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -7,10 +7,6 @@
   <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
   <title>Shopping</title>
   <link rel="stylesheet" href="styles.css">
-  <link rel="stylesheet" href="../src/components/overview/overview-styles.css">
-  <link rel="stylesheet" href="../src/components/ratings/ratings-styles.css">
-  <link rel="stylesheet" href="../src/components/shared/star-styles.css">
-  <link rel="stylesheet" href="../src/components/questions/questions-styles.css">
   <link rel="stylesheet" href="questions-styles.css">
   <link rel="stylesheet" href="overview-styles.css">
   <link rel="stylesheet" href="ratings-styles.css">

--- a/client/dist/overview-styles.css
+++ b/client/dist/overview-styles.css
@@ -161,6 +161,14 @@
   direction: rtl;
   overflow-x: hidden;
   padding: 7.5px 0px 7.5px 0px;
+  -webkit-mask-image: linear-gradient(to bottom, black 70%, transparent 97%);
+  mask-image: linear-gradient(to bottom, black 70%, transparent 97);
+}
+
+#thumb-buffer-top, #thumb-buffer-bottom {
+  min-width: 70px;
+  min-height: 100px;
+  vertical-align: bottom;
 }
 
 #thumb-container {

--- a/client/dist/overview-styles.css
+++ b/client/dist/overview-styles.css
@@ -127,6 +127,10 @@
   cursor: zoom-in;
 }
 
+#main-imagem:hover {
+  transform: scale(1.5);
+}
+
 #expand-icon, #collapse-icon {
   width: 20px;
   height: 20px;
@@ -151,7 +155,7 @@
   direction: ltr;
 }
 
-#thumbs {
+#thumbs, #thumbs-fadeout {
   display: flex;
   flex-direction: column;
   width: 100px;
@@ -164,6 +168,11 @@
   -webkit-mask-image: linear-gradient(to bottom, black 70%, transparent 97%);
   mask-image: linear-gradient(to bottom, black 70%, transparent 97);
 }
+
+/* #thumbs-fadeout {
+  -webkit-mask-image: linear-gradient(to bottom, black 70%, transparent 97%);
+  mask-image: linear-gradient(to bottom, black 70%, transparent 97);
+} */
 
 #thumb-buffer-top, #thumb-buffer-bottom {
   min-width: 70px;

--- a/client/dist/ratings-styles.css
+++ b/client/dist/ratings-styles.css
@@ -193,9 +193,6 @@
   font: 13px;
 }
 
-
-
-
 .review-bottom-buttons {
   display: flex;
   flex-direction: row;

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -3,7 +3,7 @@ import Overview from './overview/Overview.jsx';
 import Ratings from './ratings/Ratings.jsx';
 import QnA from './questions/QnA.jsx';
 
-let id = 40346
+let id = 40348
 
 var App = (props) => (
   <div>

--- a/client/src/components/overview/Overview.jsx
+++ b/client/src/components/overview/Overview.jsx
@@ -88,7 +88,6 @@ const Overview = ({ id }) => {
 
       axios(GetProductReviews(id))
       .then(response => {
-        console.log(response.data)
         setReviews(response.data)
       })
       .catch(err => {

--- a/client/src/components/overview/overview-components/Carousel.jsx
+++ b/client/src/components/overview/overview-components/Carousel.jsx
@@ -5,6 +5,14 @@ import styles from '../../../../sample/styles.js'
 const Carousel = ({styles, currentStyle, image, setImage, view, changeView}) => {
   useEffect(() => {
     let thumbWindow = document.getElementById('thumbs')
+
+    // if (styles.results[currentStyle].photos.length > 7) {
+
+    //   thumbWindow = document.getElementById('thumbs-fadeout')
+    // } else {
+
+    //   thumbWindow = document.getElementById('thumbs')
+    // }
     // window.scrollTo(0,document.body.scrollHeight);
     if (view === 'default') {
       let focusThumb = document.getElementById('thumb-highlight')
@@ -95,7 +103,13 @@ const Thumbs = ({style, onClick, image, view}) => {
   return (
     <div>
       {view === 'default' &&
-        <div id='thumbs'>
+        <div id='thumbs'
+          // id={
+          //   style.photos.length > 7 ?
+          //   'thumbs-fadeout' :
+          //   'thumbs'
+          // }
+        >
           {/* <div id='thumb-buffer-top'></div> */}
           {style.photos.map((photo, i) =>
           <Thumb
@@ -105,7 +119,7 @@ const Thumbs = ({style, onClick, image, view}) => {
             onClick={onClick}
             image={image}
           />)}
-          <div id='thumb-buffer-bottom'></div>
+          {style.photos.length > 7 && <div id='thumb-buffer-bottom'></div>}
         </div>
       }
     </div>

--- a/client/src/components/overview/overview-components/Carousel.jsx
+++ b/client/src/components/overview/overview-components/Carousel.jsx
@@ -4,11 +4,20 @@ import styles from '../../../../sample/styles.js'
 
 const Carousel = ({styles, currentStyle, image, setImage, view, changeView}) => {
   useEffect(() => {
+    let thumbWindow = document.getElementById('thumbs')
+    // window.scrollTo(0,document.body.scrollHeight);
     if (view === 'default') {
       let focusThumb = document.getElementById('thumb-highlight')
-      focusThumb.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start'})
+      if (image === styles.results[currentStyle].photos.length - 1) {
+        thumbWindow.scrollTo(0, thumbs.scrollHeight)
+      } else if (image === 0) {
+        thumbWindow.scrollTo(0, 0)
+      }
+      else {
+        focusThumb.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start'})
+      }
     }
-  }, [image])
+  }, [image, view])
 
   const onClickThumb = (index) => {
     setImage(index)
@@ -87,6 +96,7 @@ const Thumbs = ({style, onClick, image, view}) => {
     <div>
       {view === 'default' &&
         <div id='thumbs'>
+          {/* <div id='thumb-buffer-top'></div> */}
           {style.photos.map((photo, i) =>
           <Thumb
             key={i}
@@ -95,6 +105,7 @@ const Thumbs = ({style, onClick, image, view}) => {
             onClick={onClick}
             image={image}
           />)}
+          <div id='thumb-buffer-bottom'></div>
         </div>
       }
     </div>


### PR DESCRIPTION
## Fadeout effect

**WIP:** *Fadeout effect will not be visible if there are 7 or less thumbnails.*

If thumbnail count exceeds 7, bottom thumbnails have fadeout effect indicating to the user that they can scroll for more images.

If the first thumbnail is selected, thumbnail scrollbar snaps fully to the top of the thumb wheel. If the last thumbnail is selected, scrollbar snaps fully to the bottom with some buffer empty space so last thumbnail comes fully into view.

Exiting Expanded View now maintains selected thumbnail when returning to Default View.
![Thumbnail-fadeout](https://user-images.githubusercontent.com/58197934/140105499-0e9bbc1d-014e-4e1d-a1a4-b4883b4f1d34.gif)

*Ticket*
https://trello.com/c/RhTGQ8tS
