### PR TITLE
2.5x Magnified View

### DIFF
--- a/client/dist/overview-styles.css
+++ b/client/dist/overview-styles.css
@@ -132,14 +132,15 @@
 #magnify-container {
   width: 1200px;
   height: 600px;
-  position: absolute;
   overflow: hidden;
   border-radius: 25px;
+  position: absolute;
 }
 
 #main-image-zoomed {
-  /* object-fit: cover; */
-  /* transform: scale(2.5); */
+  /* position: relative;
+  top: 0px;
+  left: 0px; */
 }
 
 #expand-icon, #collapse-icon {

--- a/client/dist/overview-styles.css
+++ b/client/dist/overview-styles.css
@@ -134,14 +134,12 @@
   height: 600px;
   position: absolute;
   overflow: hidden;
+  border-radius: 25px;
 }
 
 #main-image-zoomed {
-  object-fit: cover;
-  width: 1200px;
-  height: 600px;
-  overflow: hidden;
-  transform: scale(2.5);
+  /* object-fit: cover; */
+  /* transform: scale(2.5); */
 }
 
 #expand-icon, #collapse-icon {

--- a/client/dist/overview-styles.css
+++ b/client/dist/overview-styles.css
@@ -129,6 +129,13 @@
   cursor: zoom-in;
 }
 
+#magnify-container {
+  width: 1200px;
+  height: 600px;
+  position: absolute;
+  overflow: hidden;
+}
+
 #main-image-zoomed {
   object-fit: cover;
   width: 1200px;

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -3,7 +3,7 @@ import Overview from './overview/Overview.jsx';
 import Ratings from './ratings/Ratings.jsx';
 import QnA from './questions/QnA.jsx';
 
-let id = 40347
+let id = 40348
 
 var App = (props) => (
   <div>

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -3,7 +3,7 @@ import Overview from './overview/Overview.jsx';
 import Ratings from './ratings/Ratings.jsx';
 import QnA from './questions/QnA.jsx';
 
-let id = 40348
+let id = 40347
 
 var App = (props) => (
   <div>

--- a/client/src/components/overview/RequestAPI.jsx
+++ b/client/src/components/overview/RequestAPI.jsx
@@ -6,7 +6,7 @@ import key from '../../../../auth.js'
 const GetProductInformation = (id) => {
   let productInformation = {
     method: 'get',
-    url: `https://app-hrsei-api.herokuapp.com/api/fec2/hr-rfp/products/${id}`,
+    url: `api/products/${id}`,
     headers: { Authorization : key }
   }
   return productInformation
@@ -15,7 +15,7 @@ const GetProductInformation = (id) => {
 const GetProductStyles = (id) => {
     let productStyles = {
       method: 'get',
-      url: `https://app-hrsei-api.herokuapp.com/api/fec2/hr-rfp/products/${id}/styles`,
+      url: `api/products/${id}/styles`,
       headers: { Authorization : key }
     }
   return productStyles
@@ -24,7 +24,7 @@ const GetProductStyles = (id) => {
 const GetProductReviews = (id) => {
   let productReviews = {
     method: 'get',
-    url: `https://app-hrsei-api.herokuapp.com/api/fec2/hr-rfp/reviews/meta/?product_id=${id}`,
+    url: `api/reviews/meta/?product_id=${id}`,
     headers: { Authorization : key }
   }
 return productReviews

--- a/client/src/components/overview/overview-components/Carousel.jsx
+++ b/client/src/components/overview/overview-components/Carousel.jsx
@@ -5,8 +5,8 @@ import Arrows from './NavigationArrows.jsx'
 
 
 const Zoomed = ({styles, currentStyle, image, changeView, view}) => {
-  const [imageX, setImageX] = useState()
-  const [imageY, setImageY] = useState()
+  const [imageX, setImageX] = useState(0)
+  const [imageY, setImageY] = useState(0)
 
   // useEffect(()=> {
     // setImageX(e.currentTarget.offsetWidth)
@@ -14,15 +14,19 @@ const Zoomed = ({styles, currentStyle, image, changeView, view}) => {
   // }, [imageX, imageY])
 
 
-  const logCoords = (e) => {
+  const magnifyScale = (e) => {
     setImageX(e.currentTarget.offsetWidth)
     setImageY(e.currentTarget.offsetHeight)
+    e.currentTarget.style.transform = 'scale(2.5)'
+  }
+
+  const getMouseCoords = (e) => {
     // console.log(e.screenX)
     // console.log(e.screenY)
-    //transform: translate
-    // console.log(e.currentTarget.offsetWidth)
-    // console.log(e.currentTarget.offsetHeight)
-    e.currentTarget.style.transform = 'scale(2.5)'
+    // console.log(e.clientX)
+    // console.log(e.clientY)
+    setImageX(e.clientX)
+    setImageY(e.clientY)
   }
 
   return (
@@ -33,12 +37,11 @@ const Zoomed = ({styles, currentStyle, image, changeView, view}) => {
           >
           <img
             id='main-image-zoomed'
-            // onMouseMove={logCoords}
-            onMouseOver={logCoords}
+            onMouseMove={getMouseCoords}
+            onMouseOver={magnifyScale}
             src={styles.results[currentStyle].photos[image].url}
             onClick={() => changeView(view, 'image')}
-            // width={(imageX * 2.5).toString()}
-            // height={(imageY * 2.5).toString()}
+            style={{position: 'relative', left: -imageX, top: -imageY}}
           />
         </div>
       }
@@ -189,50 +192,3 @@ const Thumb = ({thumb, index, onClick, image, view}) => {
 
 export default Carousel
 export {Thumbs, Thumb}
-
-
-// / Extract the URL
-// zoomBoxes.forEach(function(image) {
-//   var imageCss = window.getComputedStyle(image, false),
-//     imageUrl = imageCss.backgroundImage
-//                        .slice(4, -1).replace(/['"]/g, '');
-
-//   // Get the original source image
-//   var imageSrc = new Image();
-//   imageSrc.onload = function() {
-//     var imageWidth = imageSrc.naturalWidth,
-//         imageHeight = imageSrc.naturalHeight,
-//         ratio = imageHeight / imageWidth;
-
-//     // Adjust the box to fit the image and to adapt responsively
-//     var percentage = ratio * 100 + '%';
-//     image.style.paddingBottom = percentage;
-
-//     // Zoom and scan on mousemove
-//     image.onmousemove = function(e) {
-//       // Get the width of the thumbnail
-//       var boxWidth = image.clientWidth,
-//           // Get the cursor position, minus element offset
-//           x = e.pageX - this.offsetLeft,
-//           y = e.pageY - this.offsetTop,
-//           // Convert coordinates to % of elem. width & height
-//           xPercent = x / (boxWidth / 100) + '%',
-//           yPercent = y / (boxWidth * ratio / 100) + '%';
-
-//       // Update styles w/actual size
-//       Object.assign(image.style, {
-//         backgroundPosition: xPercent + ' ' + yPercent,
-//         backgroundSize: imageWidth + 'px'
-//       });
-//     };
-
-//     // Reset when mouse leaves
-//     image.onmouseleave = function(e) {
-//       Object.assign(image.style, {
-//         backgroundPosition: 'center',
-//         backgroundSize: 'cover'
-//       });
-//     };
-//   }
-//   imageSrc.src = imageUrl;
-// });

--- a/client/src/components/overview/overview-components/Carousel.jsx
+++ b/client/src/components/overview/overview-components/Carousel.jsx
@@ -5,8 +5,8 @@ import Arrows from './NavigationArrows.jsx'
 
 
 const Zoomed = ({styles, currentStyle, image, changeView, view}) => {
-  const [imageX, setImageX] = useState(0)
-  const [imageY, setImageY] = useState(0)
+  const [mouseX, setMouseX] = useState(0)
+  const [mouseY, setMouseY] = useState(0)
 
   // useEffect(()=> {
     // setImageX(e.currentTarget.offsetWidth)
@@ -15,18 +15,31 @@ const Zoomed = ({styles, currentStyle, image, changeView, view}) => {
 
 
   const magnifyScale = (e) => {
-    setImageX(e.currentTarget.offsetWidth)
-    setImageY(e.currentTarget.offsetHeight)
+    // console.log('width: ', e.currentTarget.offsetWidth)
+    // console.log('height: ', e.currentTarget.offsetHeight)
+    //1650x x 1100y
+
+    //left, right
+    //100-1300
+
+    //top, bottom
+    //130-730
+
     e.currentTarget.style.transform = 'scale(2.5)'
   }
 
   const getMouseCoords = (e) => {
     // console.log(e.screenX)
     // console.log(e.screenY)
-    // console.log(e.clientX)
-    // console.log(e.clientY)
-    setImageX(e.clientX)
-    setImageY(e.clientY)
+    console.log('X ', e.clientX)
+    console.log('Y ', e.clientY)
+
+    //1.5x ratio
+
+    setMouseX((e.clientX))
+    setMouseY((e.clientY))
+
+    // image height / 600
   }
 
   return (
@@ -41,7 +54,7 @@ const Zoomed = ({styles, currentStyle, image, changeView, view}) => {
             onMouseOver={magnifyScale}
             src={styles.results[currentStyle].photos[image].url}
             onClick={() => changeView(view, 'image')}
-            style={{position: 'relative', left: -imageX, top: -imageY}}
+            style={{position: 'relative', left: -mouseX, top: -mouseY}}
           />
         </div>
       }
@@ -49,18 +62,7 @@ const Zoomed = ({styles, currentStyle, image, changeView, view}) => {
   )
 }
 
-
-
-
 const Carousel = ({styles, currentStyle, image, setImage, view, changeView}) => {
-
-  const [mouseX, setMouseX] = useState()
-  const [mouseY, setMouseY] = useState()
-
-  useEffect(()=> {
-
-  }, [mouseX, mouseY])
-
 
   useEffect(() => {
     let thumbWindow = document.getElementById('thumbs')
@@ -98,10 +100,6 @@ const Carousel = ({styles, currentStyle, image, setImage, view, changeView}) => 
     }
     setImage(newIndex)
   }
-
-  // onClickMagnify = () => {
-
-  // }
 
   return (
     <span id=
@@ -192,3 +190,4 @@ const Thumb = ({thumb, index, onClick, image, view}) => {
 
 export default Carousel
 export {Thumbs, Thumb}
+

--- a/client/src/components/overview/overview-components/Carousel.jsx
+++ b/client/src/components/overview/overview-components/Carousel.jsx
@@ -52,14 +52,21 @@ const Carousel = ({styles, currentStyle, image, setImage, view, changeView}) => 
         'gallery-container-default-view'
       }
     >
+      {view !== 'magnify' &&
       <img
-        id={
-          view === 'default' || view === 'expanded' ?
-          'main-image' :
-          'main-image-zoomed'}
+        id='main-image'
         src={styles.results[currentStyle].photos[image].url}
         onClick={() => changeView(view, 'image')}
-      />
+      />}
+      {view === 'magnify' &&
+        <div id='magnify-container'>
+          <img
+            id='main-image-zoomed'
+            src={styles.results[currentStyle].photos[image].url}
+            onClick={() => changeView(view, 'image')}
+          />
+        </div>
+      }
       {view !== 'magnify' &&
         <img
           id={view === 'default' ? 'expand-icon' : 'collapse-icon'}
@@ -73,12 +80,14 @@ const Carousel = ({styles, currentStyle, image, setImage, view, changeView}) => 
         'thumbs-outer-container'
         }
       >
+      {view !== 'magnify' &&
         <Thumbs
           style={styles.results[currentStyle]}
           onClick={onClickThumb}
           image={image}
           view={view}
         />
+      }
       </div>
       {view !== 'magnify' &&
       <Arrows onClickArrow={onClickArrow} view={view} />}

--- a/client/src/components/overview/overview-components/Carousel.jsx
+++ b/client/src/components/overview/overview-components/Carousel.jsx
@@ -3,7 +3,62 @@ import {useState, useEffect} from 'react'
 import styles from '../../../../sample/styles.js'
 import Arrows from './NavigationArrows.jsx'
 
+
+const Zoomed = ({styles, currentStyle, image, changeView, view}) => {
+  const [imageX, setImageX] = useState()
+  const [imageY, setImageY] = useState()
+
+  // useEffect(()=> {
+    // setImageX(e.currentTarget.offsetWidth)
+    // setImageY(e.currentTarget.offsetHeight)
+  // }, [imageX, imageY])
+
+
+  const logCoords = (e) => {
+    setImageX(e.currentTarget.offsetWidth)
+    setImageY(e.currentTarget.offsetHeight)
+    // console.log(e.screenX)
+    // console.log(e.screenY)
+    //transform: translate
+    // console.log(e.currentTarget.offsetWidth)
+    // console.log(e.currentTarget.offsetHeight)
+    e.currentTarget.style.transform = 'scale(2.5)'
+  }
+
+  return (
+    <div>
+      {view === 'magnify' &&
+        <div
+          id='magnify-container'
+          >
+          <img
+            id='main-image-zoomed'
+            // onMouseMove={logCoords}
+            onMouseOver={logCoords}
+            src={styles.results[currentStyle].photos[image].url}
+            onClick={() => changeView(view, 'image')}
+            // width={(imageX * 2.5).toString()}
+            // height={(imageY * 2.5).toString()}
+          />
+        </div>
+      }
+    </div>
+  )
+}
+
+
+
+
 const Carousel = ({styles, currentStyle, image, setImage, view, changeView}) => {
+
+  const [mouseX, setMouseX] = useState()
+  const [mouseY, setMouseY] = useState()
+
+  useEffect(()=> {
+
+  }, [mouseX, mouseY])
+
+
   useEffect(() => {
     let thumbWindow = document.getElementById('thumbs')
     // if (styles.results[currentStyle].photos.length > 7) {
@@ -58,15 +113,13 @@ const Carousel = ({styles, currentStyle, image, setImage, view, changeView}) => 
         src={styles.results[currentStyle].photos[image].url}
         onClick={() => changeView(view, 'image')}
       />}
-      {view === 'magnify' &&
-        <div id='magnify-container'>
-          <img
-            id='main-image-zoomed'
-            src={styles.results[currentStyle].photos[image].url}
-            onClick={() => changeView(view, 'image')}
-          />
-        </div>
-      }
+      <Zoomed
+        styles={styles}
+        currentStyle={currentStyle}
+        image={image}
+        changeView={changeView}
+        view={view}
+      />
       {view !== 'magnify' &&
         <img
           id={view === 'default' ? 'expand-icon' : 'collapse-icon'}


### PR DESCRIPTION
## Magnified View

When user clicks main image in Expanded View, 'view' state switches to 'magnify'. 
Main image transforms scale by 2.5x. Overflow is hidden by standard viewport sizing.
When user moves cursor, zoomed image moves in relation to the mouse scrolling.

*Current issue: coordinates are not what I am expecting, so I am unable to do the math for proper ratio relationship for scrolling viewport vs. actual zoomed image size. WIP*

![zoomed-view-WIP](https://user-images.githubusercontent.com/58197934/140383827-d58e3642-23fb-40c8-90de-a80e1621e478.gif)

![Screen Shot 2021-11-04 at 9 17 25 AM](https://user-images.githubusercontent.com/58197934/140383852-192c6c5a-d088-41c0-ac51-ca06ed2bb092.png)

*Ticket*
https://trello.com/c/cG7Yw5L0

