### PR TITLE
*bugfix* set style to zero on product change

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import Overview from './overview/Overview.jsx';
 import Ratings from './ratings/Ratings.jsx';
 import QnA from './questions/QnA.jsx';
@@ -11,6 +11,10 @@ let id = 40344
 
 var App = () => {
   const [mainProduct, setMainProduct] = useState(40344)
+
+  useEffect(()=> {
+    window.scrollTo(0, 0);
+  }, [mainProduct])
 
   const handleProductChange = (idClicked) => {
     setMainProduct(idClicked)

--- a/client/src/components/overview/Overview.jsx
+++ b/client/src/components/overview/Overview.jsx
@@ -16,6 +16,11 @@ const Overview = ({ id }) => {
   const [view, setView] = useState('default')
 
   useEffect(() => {
+    setImage(0)
+    setCurrentStyle(0)
+  }, [product])
+
+  useEffect(() => {
     axios(`api/products/${id}`)
       .then(response => {
         setProduct(response.data)
@@ -43,8 +48,6 @@ const Overview = ({ id }) => {
 
   const handleOnClick = (styleNum) => {
     setCurrentStyle(styleNum)
-    //to reset image to first image on style change:
-    /*setImage(0)*/
   }
 
   const changeView = (viewType, from) => {

--- a/client/src/components/related/Related.jsx
+++ b/client/src/components/related/Related.jsx
@@ -85,9 +85,7 @@ const RelatedPrice = ({price}) => (
 
 const Related = ({id, handleProductChange}) => {
   const [related, setRelated] = useState()
-  //do /products/:product_id/related GET
-  //make a card for each id in array
-  //each card does /products/:product_id GET
+
   useEffect(() => {
     axios.get(`api/products/${id}/related`)
     .then(response => {


### PR DESCRIPTION
Switching products now sets currently viewed style to 0 to prevent bug where user switches to product with less styles.

*Example*
If user had selected style #5, and switched to a product with only 4 styles, a bug would occur.

Page also now auto-scrolls to top on product change.