### PR TITLE
*bugfix* switching styles now defaults to image 1.

### DIFF
--- a/client/src/components/overview/Overview.jsx
+++ b/client/src/components/overview/Overview.jsx
@@ -46,6 +46,7 @@ const Overview = ({ id }) => {
 
   const handleOnClick = (styleNum) => {
     setCurrentStyle(styleNum)
+    setImage(0)
   }
 
   const changeView = (viewType, from) => {

--- a/client/src/components/overview/overview-components/Carousel.jsx
+++ b/client/src/components/overview/overview-components/Carousel.jsx
@@ -132,7 +132,7 @@ const Thumbs = ({style, onClick, image, view}) => {
           image={image}
           view={view}
         />)}
-        {style.photos.length > 7 && <div id='thumb-buffer-bottom'></div>}
+        {/* {style.photos.length > 7 && <div id='thumb-buffer-bottom'></div>} */}
       </div>
     </div>
   )


### PR DESCRIPTION
When user switches styles, main photo now switches to photo #1 in the set. This is to prevent a bug where the user may switch to a style that has less photos in the set.

*Example*
User is viewing photo #10 in style 1. They switch to style 2 that only has 9 photos. This created a bug.